### PR TITLE
Revert "feat: implementing position-independent code"

### DIFF
--- a/restore.lds
+++ b/restore.lds
@@ -12,7 +12,7 @@ SECTIONS
   /*--------------------------------------------------------------------*/
 
   /* Beginning of code and text segment */
-  . = ALIGN(4);
+  . = 0x80000000;
   gcpt_begin = .;
 
   .restore.size :
@@ -34,8 +34,7 @@ SECTIONS
 
   gcpt_end = .;
 
-
-  . = gcpt_begin + 0x100000;
+  . = 0x80100000;
   .payload :
   {
     PROVIDE(_payload_start = .);

--- a/src/csr.h
+++ b/src/csr.h
@@ -57,8 +57,6 @@
   li t0, MSTATUS_VS; \
   csrs  CSR_MSTATUS, t0; \
   li t0, CSR_REG_CPT_ADDR; \
-  la t1, place_of_restore_size; \
-  add t0, t0, t1; \
   li t2,VTYPE_ID;\
   slli t2,t2,3; \
   add t2,t0,t2; \
@@ -72,8 +70,6 @@
 #define RESTORE_VECTORS(f) \
   VTYPE_VL_RESTORE; \
   li sp, VECTOR_REG_CPT_ADDR; \
-  la t0, place_of_restore_size; \
-  add sp, sp, t0; \
   addi sp,sp,0;\
   vl1re64.v v0, (sp); \
   addi sp,sp,16;\

--- a/src/restore.S
+++ b/src/restore.S
@@ -36,13 +36,10 @@ boot_decide_vector:
   bne t1, t2, read_incomplete # read incomplete goto bad_trap
 
   li s0, BOOT_FLAG_ADDR
-  la s1, place_of_restore_size
-  add s0, s0, s1
   ld t1, (s0) #load boot flag
   li t2, CPT_MAGIC_BUMBER
   beq t1, t2, restore_csr_vector
-  li t0, 0x80000000
-  jalr x0, 0(t0) # not found restore flag, goto payload
+  j payload_bin # not found restore flag, goto payload
 
 #version_not_match:
 #  li a0, VERSION_NOT_MATCH
@@ -67,8 +64,6 @@ restore_trap_handler:
 #
 restore_csr_vector:
   li t0, CSR_REG_CPT_ADDR
-  la t1, place_of_restore_size
-  add t0, t0, t1
   li t2, 0x003
   slli t2, t2, 3
   add t2, t0, t2
@@ -78,8 +73,6 @@ restore_csr_vector:
   csrw 0x003, t1
 
   li t0, CSR_REG_CPT_ADDR
-  la t1, place_of_restore_size
-  add t0, t0, t1
   CSRS(CSRS_RESTORE)
 
 hext_csr_restore:
@@ -88,8 +81,6 @@ hext_csr_restore:
   and t0, t0, t1
   bne t0,t1,vext_restore
   li t0, CSR_REG_CPT_ADDR
-  la t1, place_of_restore_size
-  add t0, t0, t1
   HCSRS(CSRS_RESTORE)
 
 vext_restore:
@@ -99,14 +90,10 @@ vext_restore:
   bne t0,t1,normal_csr_restore
   RESTORE_VECTORS(CSRS_RESTORE)
   li t0, CSR_REG_CPT_ADDR
-  la t1, place_of_restore_size
-  add t0, t0, t1
 
 normal_csr_restore:
   li t0, MSTATUS_MPP # MPP is M
   li s2, MODE_CPT_ADDR
-  la t1, place_of_restore_size
-  add s2, s2, t1
   ld s2, (s2) #load mode flag into s2
   slli t1, s2, 11 # mode flag shift to MPP
   beq t0, t1, mode_bad #bad trap if mode flag is M
@@ -114,15 +101,11 @@ normal_csr_restore:
   # set mtime (inaccurate) and mtimecmp
   li t0, CLINT_MMIO+CLINT_MTIMECMP
   li t1, MTIME_CMP_CPT_ADDR
-  la t2, place_of_restore_size
-  add t1, t1, t2
   ld t1, (t1)
   sd t1, (t0)
 ###
   li t0, CLINT_MMIO+CLINT_MTIME
   li t1, MTIME_CPT_ADDR
-  la t2, place_of_restore_size
-  add t1, t1, t2
   ld t1, (t1)
   sd t1, (t0)
 
@@ -135,8 +118,6 @@ normal_csr_restore:
 
 restore_float_vector:
   li sp, FLOAT_REG_CPT_ADDR # load float section addr
-  la t0, place_of_restore_size
-  add sp, sp, t0
 
   # set fs
   li t0, MSTATUS_FS
@@ -177,8 +158,6 @@ restore_float_vector:
 
 restore_int_vector:
   li sp, INT_REG_CPT_ADDR # load int section addr
-  la t1, place_of_restore_size
-  add sp, sp, t1 # load int section addr
   ld x1, (1*8)(sp)
   ld x3, (3*8)(sp)
   ld x4, (4*8)(sp)

--- a/src/restore_rom_addr.h
+++ b/src/restore_rom_addr.h
@@ -17,30 +17,34 @@
 #define __RESTORE_ROM_ADDR__
 
 #define CPT_MAGIC_BUMBER        0xbeef
-#define BOOT_CODE               0x0
+#define BOOT_CODE               0x80000000
 
-#define BOOT_FLAG_ADDR          0xECDB0
-#define PC_CPT_ADDR             0xECDB8
-#define MODE_CPT_ADDR           0xECDC0
-#define MTIME_CPT_ADDR          0xECDC8
-#define MTIME_CMP_CPT_ADDR      0xECDD0
-#define MISC_DONE_CPT_ADDR      0xECDD8
-#define MISC_RESERVE            0xECDE0
+#define BOOT_FLAG_ADDR          0x800ECDB0
+#define PC_CPT_ADDR             0x800ECDB8
+#define MODE_CPT_ADDR           0x800ECDC0
+#define MTIME_CPT_ADDR          0x800ECDC8
+#define MTIME_CMP_CPT_ADDR      0x800ECDD0
+#define MISC_DONE_CPT_ADDR      0x800ECDD8
+#define MISC_RESERVE            0x800ECDE0
 
-#define INT_REG_CPT_ADDR        0xEDDE0
-#define INT_REG_DONE            0xEDEE0
+#define INT_REG_CPT_ADDR        0x800EDDE0
+#define INT_REG_DONE            0x800EDEE0
 
-#define FLOAT_REG_CPT_ADDR      0xEDEE8
-#define FLOAT_REG_DONE          0xEDFE8
+#define FLOAT_REG_CPT_ADDR      0x800EDEE8
+#define FLOAT_REG_DONE          0x800EDFE8
 
-#define CSR_REG_CPT_ADDR        0xEDFF0
-#define CSR_REG_DONE            0xF5FF0
-#define CSR_RESERVE             0xF5FF8
+#define CSR_REG_CPT_ADDR        0x800EDFF0
+#define CSR_REG_DONE            0x800F5FF0
+#define CSR_RESERVE             0x800F5FF8
 
-#define VECTOR_REG_CPT_ADDR     0xFDFF8
-#define VECTOR_REG_DONE         0xFFFF8
+#define VECTOR_REG_CPT_ADDR     0x800FDFF8
+#define VECTOR_REG_DONE         0x800FFFF8
 
-#define GCPT_CHECKPOINT_VERSION 0xFFFFC
+#define GCPT_CHECKPOINT_VERSION 0x800FFFFC
+
+#ifndef RESET_VECTOR
+    #define RESET_VECTOR        0x80100000
+#endif
 
 #define CLINT_MMIO              0x38000000
 #define CLINT_MTIMECMP          0x4000


### PR DESCRIPTION
Reverts OpenXiangShan/LibCheckpointAlpha#6, because NEMU still not update to match this patch, so i think we should revert for now, i'll bring these change back, when NEMU is ready